### PR TITLE
解决“关于使用 seajs 依赖 arale模块合并的问题 #21”

### DIFF
--- a/tasks/lib/script.js
+++ b/tasks/lib/script.js
@@ -63,7 +63,7 @@ exports.init = function(grunt) {
 
         options.paths.some(function(basedir) {
           var fpath = path.join(basedir, dep);
-          if (!/\.css$/.test(dep)) {
+          if (!/\.(css|js)$/.test(dep)) {
             fpath += '.js';
           }
           if (grunt.file.exists(fpath)) {


### PR DESCRIPTION
造成此问题的原因是当检索一个.js文件时，也添加了“.js”后缀造成错误的后缀“.js.js”
