### PR TITLE
防止重复合并。

### DIFF
--- a/tasks/lib/script.js
+++ b/tasks/lib/script.js
@@ -31,8 +31,8 @@ exports.init = function(grunt) {
     }
 
     function updateRecords(data) {
-      var meta = ast.parse(data).map(function(m) { return m.id });
-      records = grunt.util._.union(records, meta);
+      var ids = ast.parse(data).map(function(m) { return m.id });
+      records = grunt.util._.union(records, ids);
     }
 
     var rv = meta.dependencies.map(function(dep) {

--- a/test/expected/a.js
+++ b/test/expected/a.js
@@ -1,5 +1,3 @@
-define('a', [], {})
+define("a", [], {});
 
-
-define('b', ['./b'], {})
-
+define("b", [ "./b" ], {});


### PR DESCRIPTION
检查每一个依赖文件，已经合并进来的就不需要合并了。
